### PR TITLE
Exceptions

### DIFF
--- a/lib/Geo/Coder/Google/V3.pm
+++ b/lib/Geo/Coder/Google/V3.pm
@@ -85,6 +85,14 @@ sub geocode {
     my $json = JSON->new->utf8;
     my $data = $json->decode($res->content);
 
+    if ($data->{status} eq 'OVER_QUERY_LIMIT') {
+        Carp::croak("Google Maps API exceeded query limit");
+    } elsif ($data->{status} eq 'REQUEST_DENIED') {
+        Carp::croak("Google Maps API request denied");
+    } elsif ($data->{status} eq 'INVALID_REQUEST') {
+        Carp::croak("Google Maps API invalid request");
+    }
+
     my @results = @{ $data->{results} || [] };
     wantarray ? @results : $results[0];
 }


### PR DESCRIPTION
Currently geo-coder-google fails silently and returns an empty arrayref when the response status code (https://developers.google.com/maps/documentation/geocoding/#StatusCodes) is not "OK", which makes it very hard for the developer to distinguish between an exception and a query with no results.

I have added a couple of exceptions to the geocode method in G:C:G:V3 to fix this
