### PR TITLE
Don't croak when Google returns ZERO_RESULTS

### DIFF
--- a/lib/Geo/Coder/Google/V3.pm
+++ b/lib/Geo/Coder/Google/V3.pm
@@ -111,7 +111,9 @@ sub geocode {
     my $json = JSON->new->utf8;
     my $data = $json->decode($res->content);
 
-    Carp::croak(sprintf "Google Maps API returned status '%s'", $data->{status}) unless $data->{status} eq 'OK';
+    unless ($data->{status} eq 'OK' || $data->{status} eq 'ZERO_RESULTS') {
+        Carp::croak(sprintf "Google Maps API returned status '%s'", $data->{status});
+    }
 
     my @results = @{ $data->{results} || [] };
     wantarray ? @results : $results[0];

--- a/t/01_v3_live.t
+++ b/t/01_v3_live.t
@@ -6,7 +6,7 @@ use Encode ();
 use Geo::Coder::Google;
 
 if ($ENV{TEST_GEOCODER_GOOGLE_LIVE}) {
-  plan tests => 13;
+  plan tests => 14;
 } else {
   plan skip_all => 'Not running live tests. Set $ENV{TEST_GEOCODER_GOOGLE_LIVE} = 1 to enable';
 }
@@ -44,6 +44,12 @@ SKIP: {
     my $location = $geocoder->geocode(location => 'New York');
     delta_ok($location->{geometry}{location}{lat}, 40.71278, 'Latitude for NYC');
     delta_ok($location->{geometry}{location}{lng}, -74.0059731, 'Longitude for NYC');
+}
+
+{
+    my $geocoder = Geo::Coder::Google->new(apiver => 3);
+    my $location = $geocoder->geocode('fdhkjafhdkjfhadskjfhasjklfhdlsak');
+    is( $location, undef, "No location on zero results" );
 }
 
 SKIP: {


### PR DESCRIPTION
From 0.11_03 (commit 95b26f3), Geo::Coder::Google::V3 croaks when Google
returns ZERO_RESULTS as the status.

Since there exists a reasonable way for the function to indicate zero results
(return an empty array), croaking seems a bit hard handed.

It might be that Google have changed the API to return the ZERO_RESULTS since
the commit mentioned above was introduced.

This commit fixes RT bug #104618.

Let me know if this is acceptable or if you wish me to make any changes.

Thanks in advance,
Klaus