### PR TITLE
fix metadata and prereqs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,9 @@
 Revision history for Perl extension Geo::Coder::Google
+
+0.17
+   - update metadata to v2: listing test prereqs properly, and update the
+     github repository
+
 0.16 Tue Aug 11 10:16:31 EDT 2015
    - release 0.15_01 as a non-dev release
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,17 +13,24 @@ WriteMakefile(
         URI => 0,
         'HTTP::Request' => 0,
     },
-    'BUILD_REQUIRES' => {
+    'TEST_REQUIRES' => {
         'Test::More' => 0.32,
         'Test::Number::Delta' => 0,
         'Digest::HMAC_SHA1' => 0,
         'MIME::Base64' => 0,
     },
     META_MERGE      => {
+        'meta-spec' => { version => 2 },
         resources => {
-            license     => 'http://dev.perl.org/licenses/',
-            bugtracker  => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Geo-Coder-Google',
-            repository  => 'https://github.com/miyagawa/geo-coder-google',
+            bugtracker  => {
+                web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Geo-Coder-Google',
+                mailto => 'bug-Geo-Coder-Google@rt.cpan.org',
+            },
+            repository  => {
+                type => 'git',
+                url => 'https://github.com/arcanez/geo-coder-google.git',
+                web => 'https://github.com/arcanez/geo-coder-google',
+            },
         },
     },
 );

--- a/lib/Geo/Coder/Google.pm
+++ b/lib/Geo/Coder/Google.pm
@@ -2,7 +2,7 @@ package Geo::Coder::Google;
 
 use strict;
 use warnings;
-our $VERSION = '0.16';
+our $VERSION = '0.17';
 
 sub new {
     my ($self, %param) = @_;

--- a/lib/Geo/Coder/Google/V2.pm
+++ b/lib/Geo/Coder/Google/V2.pm
@@ -2,7 +2,7 @@ package Geo::Coder::Google::V2;
 
 use strict;
 use warnings;
-our $VERSION = '0.16';
+our $VERSION = '0.17';
 
 use Carp;
 use Encode;

--- a/lib/Geo/Coder/Google/V3.pm
+++ b/lib/Geo/Coder/Google/V3.pm
@@ -2,7 +2,7 @@ package Geo::Coder::Google::V3;
 
 use strict;
 use warnings;
-our $VERSION = '0.16';
+our $VERSION = '0.17';
 
 use Carp;
 use Encode;


### PR DESCRIPTION
test prereqs were being listed in 'build', which causes them to be installed even when using `cpanm --notest`.  I also fixed the github repo to point to this one, which is the most current.