### PR TITLE
Google API key is required

### DIFF
--- a/lib/Geo/Coder/Google/V3.pm
+++ b/lib/Geo/Coder/Google/V3.pm
@@ -23,12 +23,14 @@ sub new {
     my $channel     = delete $param{channel}  || undef;
     my $client      = delete $param{client}   || '';
     my $key         = delete $param{key}      || '';
+    my $apikey      = delete $param{apikey}   || '';
     my $components  = delete $param{components};
    
     bless { 
         ua => $ua, host => $host, language => $language, 
         region => $region, oe => $oe, channel => $channel,
-        client => $client, key => $key, components => $components,
+        client => $client, key => $key, apikey => $apikey,
+        components => $components,
     }, $class;
 }
 
@@ -93,6 +95,10 @@ sub geocode {
         # signature must be last parameter in query string or you get 403's
         $url = $uri->as_string;
         $url .= '&signature='.$signature if $signature;
+    } elsif ($self->{apikey}) {
+        $query_parameters{key} = $self->{apikey};
+        $uri->query_form(%query_parameters);
+        $url = $uri->as_string;
     }
 
     my $res = $self->{ua}->get($url);


### PR DESCRIPTION
Google API key is required for requests (again).

`
{
   "error_message" : "You must use an API key to authenticate each request to Google Maps Platform APIs. For additional information, please refer to http://g.co/dev/maps-no-account",
   "results" : [],
   "status" : "REQUEST_DENIED"
}\n
Google Maps API returned status 'REQUEST_DENIED'
`

This appears to fix RT#128197.

Re-used the previous 'apikey' object parameter to set the 'key' value in the URL query string.